### PR TITLE
Enable linux build using GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: Prepare OCaml environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy build-essential git ocaml-nox ocaml-findlib libcamlpdf-ocaml-dev
+      - name: Build
+        run: make
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: cpdfsqueeze


### PR DESCRIPTION
This PR adds a small GitHub workflows file to enable building. This ensures a compile check when pull requests are coming in. It also provides a linux binary at the build (cached for approx 2 weeks).

There is no multi-platform build although this would also be possible using GitHub actions.